### PR TITLE
release: v2.06 (any text can go here)

### DIFF
--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install or upgrade Strawberry Perl
+      - name: Install or upgrade Strawberry Perl (if needed)
         shell: pwsh
         run: |
           if (Get-Command perl -ErrorAction SilentlyContinue) {

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -75,7 +75,7 @@ jobs:
           cpan -i PAR::Packer
           cpan -if Win32::LongPath || cpanm --notest Win32::LongPath
           Write-Host "Building executable..."
-          pp -M Win32::LongPath -M Encode::Unicode -M Digest::MD5 -c -x -o "cloc-$env:VERSION_NUM.exe" cloc
+          pp -M Win32::LongPath -M Encode::Unicode -M Digest::MD5 -M PAR::Packer::DeclaredRefs -c -x -o "cloc-$env:VERSION_NUM.exe" cloc
 
       - name: Upload executable to VirusTotal and get analysis URL
         id: vt_upload


### PR DESCRIPTION
Body description:
- Can be multiline
- Will update the `Unix/NEWS` file and every version number accordingly
- Correct formatting and VT upload

Feat:
- New actions

Extra:
- Must have `VIRUSTOTAL_API_KEY` set (https://github.com/AlDanial/cloc/settings/secrets/actions/new)
- Release must have tag "release-staging", either at creation or afterwards, once ready