### PR TITLE
fix: release action (this text doesn't matter)

### DIFF
--- a/.github/workflows/release-ready.yml
+++ b/.github/workflows/release-ready.yml
@@ -29,12 +29,18 @@ jobs:
 
       - name: Package repository as tar.gz
         run: |
-          VER = "${{ steps.get_version.outputs.VERSION }}"
+          VER="${{ steps.get_version.outputs.VERSION }}"
           tar -czf cloc-$VER.tar.gz --exclude='.git' .
 
       - name: Get artifact url
         run: |
-          ARTIFACT_COMMENT=$(gh pr view ${{ github.event.pull_request.number }} --json comments -q '.comments | sort_by(.createdAt) | reverse | map(select(.body | contains("**Built executable artifact:**"))) | .[0].body')
+          ARTIFACT_COMMENT=$(gh pr view ${{ github.event.pull_request.number }} --json comments -q '
+            .comments 
+            | sort_by(.createdAt) 
+            | reverse 
+            | map(select(.body | contains("**Built executable artifact:**"))) 
+            | .[0].body
+          ')
           if [ -z "$ARTIFACT_COMMENT" ]; then
             echo "No matching comment found."
             exit 1

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 * * *
 cloc counts blank lines, comment lines, and physical lines of source code in many programming languages.
 
-Latest release:  v2.06 (Feb. 14, 2025)
+Latest release:  v2.08 (Feb. 14, 2025)
 
-[![Version](https://img.shields.io/badge/version-2.06-blue.svg)](https://github.com/AlDanial/cloc)
+[![Version](https://img.shields.io/badge/version-2.08-blue.svg)](https://github.com/AlDanial/cloc)
 [![Contributors](https://img.shields.io/github/contributors/AlDanial/cloc.svg)](https://github.com/AlDanial/cloc/graphs/contributors)
 [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.42029482.svg)](https://doi.org/10.5281/zenodo.42029482)
 [![Forks](https://img.shields.io/github/forks/AlDanial/cloc.svg)](https://github.com/AlDanial/cloc/network/members)
@@ -65,8 +65,8 @@ Step 3:  Invoke cloc to count your source files, directories, archives,
 or git commits.
 The executable name differs depending on whether you use the
 development source version (`cloc`), source for a
-released version (`cloc-2.06.pl`) or a Windows executable
-(`cloc-2.06.exe`).
+released version (`cloc-2.08.pl`) or a Windows executable
+(`cloc-2.08.exe`).
 
 On this page, `cloc` is the generic term
 used to refer to any of these.
@@ -415,14 +415,14 @@ C:> cpan -i Regexp::Common
 C:> cpan -i Algorithm::Diff
 C:> cpan -i PAR::Packer
 C:> cpan -i Win32::LongPath
-C:> pp -M Win32::LongPath -M Encode::Unicode -M Digest::MD5 -c -x -o cloc-2.06.exe cloc-2.06.pl
+C:> pp -M Win32::LongPath -M Encode::Unicode -M Digest::MD5 -c -x -o cloc-2.08.exe cloc-2.08.pl
 </pre>
 
 A variation on the instructions above is if you installed the portable
 version of Strawberry Perl, you will need to run `portableshell.bat` first
 to properly set up your environment.
 
-The Windows executable in the Releases section, <tt>cloc-2.06.exe</tt>,
+The Windows executable in the Releases section, <tt>cloc-2.08.exe</tt>,
 was built on a 64 bit Windows 10 computer using
 [Strawberry Perl](http://strawberryperl.com/)
 5.30.2 and
@@ -443,6 +443,9 @@ You are encouraged to run your own virus scanners against the
 executable and also check sites such
 https://www.virustotal.com/ .
 The entries for recent versions are:
+
+cloc-2.08.exe:
+https://www.virustotal.com/gui/file/72261bb4d8598168302b262e3c13e9710bdbd0ca4222c94aa1e7d1d3586a755e
 
 cloc-2.06.exe:
 https://www.virustotal.com/gui/file/2f63dd7222cc81860280d2d949d67c34c7f38d8c8eb19bb641e21c9a59bd67e3

--- a/Unix/NEWS
+++ b/Unix/NEWS
@@ -1,3 +1,20 @@
+                Release Notes for cloc version 2.08
+                   https://github.com/AlDanial/cloc
+                             Feb. 14, 2025
+
+Body description (this is the release notes):
+    o Can be multiline
+    o Will update the Unix/NEWS file and every version number accordingly
+    o Correct formatting and VT upload
+
+Feat:
+    o New actions
+
+Extra:
+    o Must have VIRUSTOTALAPIKEY set (https://github.com/AlDanial/cloc/settings/secrets/actions/new)
+    o Release must have tag "release-staging", either at creation or afterwards, once ready
+
+============================================================================
                 Release Notes for cloc version 2.06
                    https://github.com/AlDanial/cloc
                              Feb. 14, 2025

--- a/Unix/cloc
+++ b/Unix/cloc
@@ -29,7 +29,7 @@
 # <http://www.gnu.org/licenses/gpl.txt>.
 #
 # 1}}}
-my $VERSION = "2.06";  # odd number == beta; even number == stable
+my $VERSION = "2.08";  # odd number == beta; even number == stable
 my $URL     = "github.com/AlDanial/cloc";  # 'https://' pushes header too wide
 require 5.10.0;
 # use modules                                  {{{1

--- a/cloc
+++ b/cloc
@@ -29,7 +29,7 @@
 # <http://www.gnu.org/licenses/gpl.txt>.
 #
 # 1}}}
-my $VERSION = "2.06";  # odd number == beta; even number == stable
+my $VERSION = "2.08";  # odd number == beta; even number == stable
 my $URL     = "github.com/AlDanial/cloc";  # 'https://' pushes header too wide
 require 5.10.0;
 # use modules                                  {{{1


### PR DESCRIPTION
Body description (this is the release notes):
- Can be multiline
- Will update the `Unix/NEWS` file and every version number accordingly
- Correct formatting and VT upload

Feat:
- New actions

Extra:
- Must have `VIRUSTOTAL_API_KEY` set (https://github.com/AlDanial/cloc/settings/secrets/actions/new)
- Release must have tag "release-staging", either at creation or afterwards, once ready