### PR TITLE
release 2.10 (doesn't matter)

### DIFF
--- a/.github/workflows/release-ready.yml
+++ b/.github/workflows/release-ready.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Get artifact url
         run: |
+          GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
           ARTIFACT_COMMENT=$(gh pr view ${{ github.event.pull_request.number }} --json comments -q '
             .comments 
             | sort_by(.createdAt) 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 * * *
 cloc counts blank lines, comment lines, and physical lines of source code in many programming languages.
 
-Latest release:  v2.09 (Feb. 14, 2025)
+Latest release:  v2.10 (Feb. 14, 2025)
 
-[![Version](https://img.shields.io/badge/version-2.09-blue.svg)](https://github.com/AlDanial/cloc)
+[![Version](https://img.shields.io/badge/version-2.10-blue.svg)](https://github.com/AlDanial/cloc)
 [![Contributors](https://img.shields.io/github/contributors/AlDanial/cloc.svg)](https://github.com/AlDanial/cloc/graphs/contributors)
 [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.42029482.svg)](https://doi.org/10.5281/zenodo.42029482)
 [![Forks](https://img.shields.io/github/forks/AlDanial/cloc.svg)](https://github.com/AlDanial/cloc/network/members)
@@ -65,8 +65,8 @@ Step 3:  Invoke cloc to count your source files, directories, archives,
 or git commits.
 The executable name differs depending on whether you use the
 development source version (`cloc`), source for a
-released version (`cloc-2.09.pl`) or a Windows executable
-(`cloc-2.09.exe`).
+released version (`cloc-2.10.pl`) or a Windows executable
+(`cloc-2.10.exe`).
 
 On this page, `cloc` is the generic term
 used to refer to any of these.
@@ -415,14 +415,14 @@ C:> cpan -i Regexp::Common
 C:> cpan -i Algorithm::Diff
 C:> cpan -i PAR::Packer
 C:> cpan -i Win32::LongPath
-C:> pp -M Win32::LongPath -M Encode::Unicode -M Digest::MD5 -c -x -o cloc-2.09.exe cloc-2.09.pl
+C:> pp -M Win32::LongPath -M Encode::Unicode -M Digest::MD5 -c -x -o cloc-2.10.exe cloc-2.10.pl
 </pre>
 
 A variation on the instructions above is if you installed the portable
 version of Strawberry Perl, you will need to run `portableshell.bat` first
 to properly set up your environment.
 
-The Windows executable in the Releases section, <tt>cloc-2.09.exe</tt>,
+The Windows executable in the Releases section, <tt>cloc-2.10.exe</tt>,
 was built on a 64 bit Windows 10 computer using
 [Strawberry Perl](http://strawberryperl.com/)
 5.30.2 and
@@ -443,6 +443,9 @@ You are encouraged to run your own virus scanners against the
 executable and also check sites such
 https://www.virustotal.com/ .
 The entries for recent versions are:
+
+cloc-2.10.exe:
+https://www.virustotal.com/gui/file/8776e2e0bc5a48697b3d12008d94006cf759b4316c35c7dd42ffd58aa9ae8b87
 
 cloc-2.09.exe:
 https://www.virustotal.com/gui/file/21418ca90e1968d04f1e87fc6bbb0e3ada688ae8eb4207016f47badef354b542

--- a/Unix/NEWS
+++ b/Unix/NEWS
@@ -1,3 +1,20 @@
+                Release Notes for cloc version 2.10
+                   https://github.com/AlDanial/cloc
+                             Feb. 14, 2025
+
+Body description (release content):
+    o Can be multiline
+    o Will update the Unix/NEWS file and every version number accordingly
+    o Correct formatting and 'VT' upload
+
+Feat:
+    o New actions
+
+Extra:
+    o Must have VIRUSTOTALAPIKEY set (https://github.com/AlDanial/cloc/settings/secrets/actions/new)
+    o Release must have tag "release-ready", either at creation or afterwards, once ready
+
+============================================================================
                 Release Notes for cloc version 2.09
                    https://github.com/AlDanial/cloc
                              Feb. 14, 2025

--- a/Unix/cloc
+++ b/Unix/cloc
@@ -29,7 +29,7 @@
 # <http://www.gnu.org/licenses/gpl.txt>.
 #
 # 1}}}
-my $VERSION = "2.09";  # odd number == beta; even number == stable
+my $VERSION = "2.10";  # odd number == beta; even number == stable
 my $URL     = "github.com/AlDanial/cloc";  # 'https://' pushes header too wide
 require 5.10.0;
 # use modules                                  {{{1

--- a/cloc
+++ b/cloc
@@ -29,7 +29,7 @@
 # <http://www.gnu.org/licenses/gpl.txt>.
 #
 # 1}}}
-my $VERSION = "2.09";  # odd number == beta; even number == stable
+my $VERSION = "2.10";  # odd number == beta; even number == stable
 my $URL     = "github.com/AlDanial/cloc";  # 'https://' pushes header too wide
 require 5.10.0;
 # use modules                                  {{{1


### PR DESCRIPTION
Body description (release content):
- Can be multiline
- Will update the `Unix/NEWS` file and every version number accordingly
- Correct formatting and 'VT' upload

Feat:
- New actions

Extra:
- Must have `VIRUSTOTAL_API_KEY` set (https://github.com/AlDanial/cloc/settings/secrets/actions/new)
- Release must have tag "release-ready", either at creation or afterwards, once ready