### PR TITLE
text

### DIFF
--- a/.github/workflows/release-ready.yml
+++ b/.github/workflows/release-ready.yml
@@ -33,6 +33,7 @@ jobs:
           git archive --format=tar.gz -o cloc-$VER.tar.gz HEAD
 
       - name: Get artifact url
+        id: get_artifact_url
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -53,14 +54,23 @@ jobs:
             exit 1
           fi
           ARTIFACT_URL=$(echo "$MATCHING_URLS" | head -n 1)
-          curl -L -o artifact.zip "$ARTIFACT_URL"
+          RUN_ID=$(echo "$ARTIFACT_URL" | grep -oP '/actions/runs/\K[0-9]+')
+          echo "RUN_ID=$RUN_ID" >> $GITHUB_OUTPUT
+          echo "Artifact URL: $ARTIFACT_URL"
+      
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: cloc-${{ steps.get_version.outputs.VERSION }}-executable
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ steps.get_artifact_url.outputs.RUN_ID }}
 
       - name: Prepare renamed release assets
         run: |
           VER="${{ steps.get_version.outputs.VERSION }}"
           cp cloc cloc-$VER.pl
           cp Unix/NEWS release_notes-$VER.txt
-          unzip artifact.zip
+          unzip cloc-$VER-executable.zip
 
       - name: Create GitHub release with assets
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 * * *
 cloc counts blank lines, comment lines, and physical lines of source code in many programming languages.
 
-Latest release:  v2.12 (Feb. 14, 2025)
+Latest release:  v2.14 (Feb. 14, 2025)
 
-[![Version](https://img.shields.io/badge/version-2.12-blue.svg)](https://github.com/AlDanial/cloc)
+[![Version](https://img.shields.io/badge/version-2.14-blue.svg)](https://github.com/AlDanial/cloc)
 [![Contributors](https://img.shields.io/github/contributors/AlDanial/cloc.svg)](https://github.com/AlDanial/cloc/graphs/contributors)
 [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.42029482.svg)](https://doi.org/10.5281/zenodo.42029482)
 [![Forks](https://img.shields.io/github/forks/AlDanial/cloc.svg)](https://github.com/AlDanial/cloc/network/members)
@@ -65,8 +65,8 @@ Step 3:  Invoke cloc to count your source files, directories, archives,
 or git commits.
 The executable name differs depending on whether you use the
 development source version (`cloc`), source for a
-released version (`cloc-2.12.pl`) or a Windows executable
-(`cloc-2.12.exe`).
+released version (`cloc-2.14.pl`) or a Windows executable
+(`cloc-2.14.exe`).
 
 On this page, `cloc` is the generic term
 used to refer to any of these.
@@ -415,14 +415,14 @@ C:> cpan -i Regexp::Common
 C:> cpan -i Algorithm::Diff
 C:> cpan -i PAR::Packer
 C:> cpan -i Win32::LongPath
-C:> pp -M Win32::LongPath -M Encode::Unicode -M Digest::MD5 -c -x -o cloc-2.12.exe cloc-2.12.pl
+C:> pp -M Win32::LongPath -M Encode::Unicode -M Digest::MD5 -c -x -o cloc-2.14.exe cloc-2.14.pl
 </pre>
 
 A variation on the instructions above is if you installed the portable
 version of Strawberry Perl, you will need to run `portableshell.bat` first
 to properly set up your environment.
 
-The Windows executable in the Releases section, <tt>cloc-2.12.exe</tt>,
+The Windows executable in the Releases section, <tt>cloc-2.14.exe</tt>,
 was built on a 64 bit Windows 10 computer using
 [Strawberry Perl](http://strawberryperl.com/)
 5.30.2 and
@@ -443,6 +443,9 @@ You are encouraged to run your own virus scanners against the
 executable and also check sites such
 https://www.virustotal.com/ .
 The entries for recent versions are:
+
+cloc-2.14.exe:
+https://www.virustotal.com/gui/file/eb01cdf9566bd8045d51d734dce6582b29e8b74b223f02cfe4f70c9f26f5617f
 
 cloc-2.12.exe:
 https://www.virustotal.com/gui/file/00793085dc366305be69f94dcab1e443c246458b7088d41dfc21bbc5a65826d7

--- a/Unix/NEWS
+++ b/Unix/NEWS
@@ -1,3 +1,20 @@
+                Release Notes for cloc version 2.14
+                   https://github.com/AlDanial/cloc
+                             Feb. 14, 2025
+
+Body description (release content):
+    o Can be multiline
+    o Will update the Unix/NEWS file and every version number accordingly
+    o Correct formatting and 'VT' upload
+
+Feat:
+    o New actions
+
+Extra:
+    o Must have VIRUSTOTALAPIKEY set (https://github.com/AlDanial/cloc/settings/secrets/actions/new)
+    o Release must have tag "release-ready", either at creation or afterwards, once ready
+
+============================================================================
                 Release Notes for cloc version 2.12
                    https://github.com/AlDanial/cloc
                              Feb. 14, 2025

--- a/Unix/cloc
+++ b/Unix/cloc
@@ -29,7 +29,7 @@
 # <http://www.gnu.org/licenses/gpl.txt>.
 #
 # 1}}}
-my $VERSION = "2.12";  # odd number == beta; even number == stable
+my $VERSION = "2.14";  # odd number == beta; even number == stable
 my $URL     = "github.com/AlDanial/cloc";  # 'https://' pushes header too wide
 require 5.10.0;
 # use modules                                  {{{1

--- a/cloc
+++ b/cloc
@@ -29,7 +29,7 @@
 # <http://www.gnu.org/licenses/gpl.txt>.
 #
 # 1}}}
-my $VERSION = "2.12";  # odd number == beta; even number == stable
+my $VERSION = "2.14";  # odd number == beta; even number == stable
 my $URL     = "github.com/AlDanial/cloc";  # 'https://' pushes header too wide
 require 5.10.0;
 # use modules                                  {{{1


### PR DESCRIPTION
Body description (release content):
- Can be multiline
- Will update the `Unix/NEWS` file and every version number accordingly
- Correct formatting and 'VT' upload

Feat:
- New actions

Extra:
- Must have `VIRUSTOTAL_API_KEY` set (https://github.com/AlDanial/cloc/settings/secrets/actions/new)
- Release must have tag "release-ready", either at creation or afterwards, once ready