### PR TITLE
fix: dumb

### DIFF
--- a/.github/workflows/release-ready.yml
+++ b/.github/workflows/release-ready.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: cloc-${{ steps.get_version.outputs.VERSION }}-executable
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ steps.get_artifact_url.outputs.RUN_ID }}
 
       - name: Prepare renamed release assets
@@ -78,11 +78,10 @@ jobs:
           tag_name: "${{ steps.get_version.outputs.DISPLAY_VERSION }}"
           name: "${{ steps.get_version.outputs.DISPLAY_VERSION }}"
           body: "${{ github.event.pull_request.body }}"
+          token: ${{ secrets.GITHUB_TOKEN }}
           files: |
             cloc-${{ steps.get_version.outputs.VERSION }}.tar.gz
             README.md
             cloc-${{ steps.get_version.outputs.VERSION }}.pl
             cloc-${{ steps.get_version.outputs.VERSION }}.exe
             release_notes-${{ steps.get_version.outputs.VERSION }}.txt
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 * * *
 cloc counts blank lines, comment lines, and physical lines of source code in many programming languages.
 
-Latest release:  v2.14 (Feb. 14, 2025)
+Latest release:  v3.00 (Feb. 14, 2025)
 
-[![Version](https://img.shields.io/badge/version-2.14-blue.svg)](https://github.com/AlDanial/cloc)
+[![Version](https://img.shields.io/badge/version-3.00-blue.svg)](https://github.com/AlDanial/cloc)
 [![Contributors](https://img.shields.io/github/contributors/AlDanial/cloc.svg)](https://github.com/AlDanial/cloc/graphs/contributors)
 [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.42029482.svg)](https://doi.org/10.5281/zenodo.42029482)
 [![Forks](https://img.shields.io/github/forks/AlDanial/cloc.svg)](https://github.com/AlDanial/cloc/network/members)
@@ -65,8 +65,8 @@ Step 3:  Invoke cloc to count your source files, directories, archives,
 or git commits.
 The executable name differs depending on whether you use the
 development source version (`cloc`), source for a
-released version (`cloc-2.14.pl`) or a Windows executable
-(`cloc-2.14.exe`).
+released version (`cloc-3.00.pl`) or a Windows executable
+(`cloc-3.00.exe`).
 
 On this page, `cloc` is the generic term
 used to refer to any of these.
@@ -415,14 +415,14 @@ C:> cpan -i Regexp::Common
 C:> cpan -i Algorithm::Diff
 C:> cpan -i PAR::Packer
 C:> cpan -i Win32::LongPath
-C:> pp -M Win32::LongPath -M Encode::Unicode -M Digest::MD5 -c -x -o cloc-2.14.exe cloc-2.14.pl
+C:> pp -M Win32::LongPath -M Encode::Unicode -M Digest::MD5 -c -x -o cloc-3.00.exe cloc-3.00.pl
 </pre>
 
 A variation on the instructions above is if you installed the portable
 version of Strawberry Perl, you will need to run `portableshell.bat` first
 to properly set up your environment.
 
-The Windows executable in the Releases section, <tt>cloc-2.14.exe</tt>,
+The Windows executable in the Releases section, <tt>cloc-3.00.exe</tt>,
 was built on a 64 bit Windows 10 computer using
 [Strawberry Perl](http://strawberryperl.com/)
 5.30.2 and
@@ -443,6 +443,9 @@ You are encouraged to run your own virus scanners against the
 executable and also check sites such
 https://www.virustotal.com/ .
 The entries for recent versions are:
+
+cloc-3.00.exe:
+https://www.virustotal.com/gui/file/d34c09e435636aa8ef3c2390132a8112f9e833bf186dbe30638005aa78110db5
 
 cloc-2.14.exe:
 https://www.virustotal.com/gui/file/eb01cdf9566bd8045d51d734dce6582b29e8b74b223f02cfe4f70c9f26f5617f

--- a/Unix/NEWS
+++ b/Unix/NEWS
@@ -1,3 +1,20 @@
+                Release Notes for cloc version 3.00
+                   https://github.com/AlDanial/cloc
+                             Feb. 14, 2025
+
+Body description (release content):
+    o Can be multiline
+    o Will update the Unix/NEWS file and every version number accordingly
+    o Correct formatting and 'VT' upload
+
+Feat:
+    o New actions
+
+Extra:
+    o Must have VIRUSTOTALAPIKEY set (https://github.com/AlDanial/cloc/settings/secrets/actions/new)
+    o Release must have tag "release-ready", either at creation or afterwards, once ready
+
+============================================================================
                 Release Notes for cloc version 2.14
                    https://github.com/AlDanial/cloc
                              Feb. 14, 2025

--- a/Unix/cloc
+++ b/Unix/cloc
@@ -29,7 +29,7 @@
 # <http://www.gnu.org/licenses/gpl.txt>.
 #
 # 1}}}
-my $VERSION = "2.14";  # odd number == beta; even number == stable
+my $VERSION = "3.00";  # odd number == beta; even number == stable
 my $URL     = "github.com/AlDanial/cloc";  # 'https://' pushes header too wide
 require 5.10.0;
 # use modules                                  {{{1

--- a/cloc
+++ b/cloc
@@ -29,7 +29,7 @@
 # <http://www.gnu.org/licenses/gpl.txt>.
 #
 # 1}}}
-my $VERSION = "2.14";  # odd number == beta; even number == stable
+my $VERSION = "3.00";  # odd number == beta; even number == stable
 my $URL     = "github.com/AlDanial/cloc";  # 'https://' pushes header too wide
 require 5.10.0;
 # use modules                                  {{{1


### PR DESCRIPTION
Body description (release content):
- Can be multiline
- Will update the `Unix/NEWS` file and every version number accordingly
- Correct formatting and 'VT' upload

Feat:
- New actions

Extra:
- Must have `VIRUSTOTAL_API_KEY` set (https://github.com/AlDanial/cloc/settings/secrets/actions/new)
- Release must have tag "release-ready", either at creation or afterwards, once ready