### PR TITLE
chore: check where the artifact went

### DIFF
--- a/.github/workflows/release-ready.yml
+++ b/.github/workflows/release-ready.yml
@@ -70,6 +70,7 @@ jobs:
           VER="${{ steps.get_version.outputs.VERSION }}"
           cp cloc cloc-$VER.pl
           cp Unix/NEWS release_notes-$VER.txt
+          ls -R $GITHUB_WORKSPACE
           unzip cloc-$VER-executable.zip
 
       - name: Create GitHub release with assets

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 * * *
 cloc counts blank lines, comment lines, and physical lines of source code in many programming languages.
 
-Latest release:  v3.00 (Feb. 14, 2025)
+Latest release:  v3.02 (Feb. 14, 2025)
 
-[![Version](https://img.shields.io/badge/version-3.00-blue.svg)](https://github.com/AlDanial/cloc)
+[![Version](https://img.shields.io/badge/version-3.02-blue.svg)](https://github.com/AlDanial/cloc)
 [![Contributors](https://img.shields.io/github/contributors/AlDanial/cloc.svg)](https://github.com/AlDanial/cloc/graphs/contributors)
 [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.42029482.svg)](https://doi.org/10.5281/zenodo.42029482)
 [![Forks](https://img.shields.io/github/forks/AlDanial/cloc.svg)](https://github.com/AlDanial/cloc/network/members)
@@ -65,8 +65,8 @@ Step 3:  Invoke cloc to count your source files, directories, archives,
 or git commits.
 The executable name differs depending on whether you use the
 development source version (`cloc`), source for a
-released version (`cloc-3.00.pl`) or a Windows executable
-(`cloc-3.00.exe`).
+released version (`cloc-3.02.pl`) or a Windows executable
+(`cloc-3.02.exe`).
 
 On this page, `cloc` is the generic term
 used to refer to any of these.
@@ -415,14 +415,14 @@ C:> cpan -i Regexp::Common
 C:> cpan -i Algorithm::Diff
 C:> cpan -i PAR::Packer
 C:> cpan -i Win32::LongPath
-C:> pp -M Win32::LongPath -M Encode::Unicode -M Digest::MD5 -c -x -o cloc-3.00.exe cloc-3.00.pl
+C:> pp -M Win32::LongPath -M Encode::Unicode -M Digest::MD5 -c -x -o cloc-3.02.exe cloc-3.02.pl
 </pre>
 
 A variation on the instructions above is if you installed the portable
 version of Strawberry Perl, you will need to run `portableshell.bat` first
 to properly set up your environment.
 
-The Windows executable in the Releases section, <tt>cloc-3.00.exe</tt>,
+The Windows executable in the Releases section, <tt>cloc-3.02.exe</tt>,
 was built on a 64 bit Windows 10 computer using
 [Strawberry Perl](http://strawberryperl.com/)
 5.30.2 and
@@ -443,6 +443,9 @@ You are encouraged to run your own virus scanners against the
 executable and also check sites such
 https://www.virustotal.com/ .
 The entries for recent versions are:
+
+cloc-3.02.exe:
+https://www.virustotal.com/gui/file/293fa6d0b5845e2977836484e95364eecf29fb0ea06d539e41a598714601beeb
 
 cloc-3.00.exe:
 https://www.virustotal.com/gui/file/d34c09e435636aa8ef3c2390132a8112f9e833bf186dbe30638005aa78110db5

--- a/Unix/NEWS
+++ b/Unix/NEWS
@@ -1,3 +1,20 @@
+                Release Notes for cloc version 3.02
+                   https://github.com/AlDanial/cloc
+                             Feb. 14, 2025
+
+Body description (release content):
+    o Can be multiline
+    o Will update the Unix/NEWS file and every version number accordingly
+    o Correct formatting and 'VT' upload
+
+Feat:
+    o New actions
+
+Extra:
+    o Must have VIRUSTOTALAPIKEY set (https://github.com/AlDanial/cloc/settings/secrets/actions/new)
+    o Release must have tag "release-ready", either at creation or afterwards, once ready
+
+============================================================================
                 Release Notes for cloc version 3.00
                    https://github.com/AlDanial/cloc
                              Feb. 14, 2025

--- a/Unix/cloc
+++ b/Unix/cloc
@@ -29,7 +29,7 @@
 # <http://www.gnu.org/licenses/gpl.txt>.
 #
 # 1}}}
-my $VERSION = "3.00";  # odd number == beta; even number == stable
+my $VERSION = "3.02";  # odd number == beta; even number == stable
 my $URL     = "github.com/AlDanial/cloc";  # 'https://' pushes header too wide
 require 5.10.0;
 # use modules                                  {{{1

--- a/cloc
+++ b/cloc
@@ -29,7 +29,7 @@
 # <http://www.gnu.org/licenses/gpl.txt>.
 #
 # 1}}}
-my $VERSION = "3.00";  # odd number == beta; even number == stable
+my $VERSION = "3.02";  # odd number == beta; even number == stable
 my $URL     = "github.com/AlDanial/cloc";  # 'https://' pushes header too wide
 require 5.10.0;
 # use modules                                  {{{1


### PR DESCRIPTION
Body description (release content):
- Can be multiline
- Will update the `Unix/NEWS` file and every version number accordingly
- Correct formatting and 'VT' upload

Feat:
- New actions

Extra:
- Must have `VIRUSTOTAL_API_KEY` set (https://github.com/AlDanial/cloc/settings/secrets/actions/new)
- Release must have tag "release-ready", either at creation or afterwards, once ready